### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -10,7 +10,7 @@ isPressed	KEYWORD2
 isHeld	KEYWORD2
 ldrValue	KEYWORD2
 setldrThreshold	KEYWORD2
-capTouch KEYWORD2
+capTouch	KEYWORD2
 setRefreshRate	KEYWORD2
 updateDisplay	KEYWORD2
 allOn	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords